### PR TITLE
Jg us52 54 admin merchant user pages

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,18 +1,23 @@
 class Admin::MerchantsController < Admin::BaseController
-  def index 
+  def index
     @merchants = Merchant.all
   end
 
-  def show 
+  def show
     @merchant = Merchant.find(params[:id])
   end
 
-  def update 
+  def update
     merchant = Merchant.find(params[:id])
     if merchant.enabled?
       merchant.update(enabled?: false)
       merchant.deactivate_items
       flash[:notice] = "#{merchant.name} is now disabled."
+      redirect_to admin_merchants_path
+    else
+      merchant.update(enabled?: true)
+      merchant.activate_items
+      flash[:notice] = "#{merchant.name} is now enabled."
       redirect_to admin_merchants_path
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,11 @@
 class Admin::UsersController < Admin::BaseController
-  
-  def show 
+
+  def index
+    @users = User.all
+  end
+
+  def show
     @user = User.find(params[:user_id])
   end
-  
+
 end

--- a/app/controllers/admin/users_orders_controller.rb
+++ b/app/controllers/admin/users_orders_controller.rb
@@ -1,0 +1,7 @@
+class Admin::UsersOrdersController < Admin::BaseController
+
+  def index
+    @user = User.find(params[:user_id])
+  end
+
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -36,4 +36,8 @@ class Merchant <ApplicationRecord
     items.update(active?: false)
   end
 
+  def activate_items
+    items.update(active?: true)
+  end
+
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -17,15 +17,17 @@
           <% if merchant.enabled? %>
           Enabled
           <% else %>
-          Disabled 
+          Disabled
           <% end %>
         </td>
         <td>
           <% if merchant.enabled? %>
             <%= link_to 'Disable Merchant', admin_merchant_path(merchant.id), method: :patch %>
+          <% else %>
+            <%= link_to 'Enable Merchant', admin_merchant_path(merchant.id), method: :patch %>
           <% end %>
         </td>
        </section>
-    </tr> 
+    </tr>
   <% end %>
 </table>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,18 @@
+<h1>All Users</h1>
+
+<table class = "all-users">
+  <tr>
+    <th>User Name</th>
+    <th>Date Registered</th>
+    <th>Role</th>
+  </tr>
+  <% @users.each do |user| %>
+    <section id="user-<%= user.id %>">
+      <tr>
+       <td><%= link_to user.name, "/admin/users/#{user.id}" %></td>
+       <td><%= user.created_at.to_date %></td>
+       <td><%= user.role %></td>
+      </tr>
+    </section>
+  <% end %>
+</table>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,11 @@
+<p>Name: <%= @user.name %></p>
+<p>Address: <%= @user.address %></p>
+<p>City: <%= @user.city %></p>
+<p>State: <%= @user.state %></p>
+<p>Zip: <%= @user.zip %></p>
+<p>Email: <%= @user.email %></p>
+
+
+<% if !(@user.orders.empty?) %>
+  <%= link_to "Orders for #{@user.name}", "/admin/users/#{@user.id}/orders" %>
+<%end%>

--- a/app/views/admin/users_orders/index.html.erb
+++ b/app/views/admin/users_orders/index.html.erb
@@ -1,0 +1,11 @@
+<h1>My Orders</h1>
+<% @user.orders.each do |order| %>
+  <section id="order-<%= order.id %>">
+  <h3><%= link_to "Order - #{order.id}", "/profile/orders/#{order.id}" %></h3>
+  <p>Order Status: <%= order.status %></p>
+  <p>Date Placed: <%= order.created_at %></p>
+  <p>Date Last Updated: <%= order.updated_at %></p>
+  <p>Item Quantity: <%= order.total_item_quantity %></p>
+  <p>Grand Total: <%= order.grandtotal %></p>
+  </section>
+<% end %>

--- a/app/views/admin/users_orders/index.html.erb
+++ b/app/views/admin/users_orders/index.html.erb
@@ -1,4 +1,4 @@
-<h1>My Orders</h1>
+<h1>Orders for <%= @user.name %></h1>
 <% @user.orders.each do |order| %>
   <section id="order-<%= order.id %>">
   <h3><%= link_to "Order - #{order.id}", "/profile/orders/#{order.id}" %></h3>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,11 @@
     <nav class = "topnav">
       <%= link_to "Home", "/"%>
       <%= link_to "All Items", "/items"%>
-      <%= link_to "All Merchants", "/merchants"%>
+      <% if !current_admin? %>
+        <%= link_to "All Merchants", "/merchants"%>
+      <% else %>
+        <%= link_to "All Merchants", admin_merchants_path%>
+      <% end %>
       <% if !current_admin? %>
         <%= link_to "Cart: #{cart.total_items}", "/cart" %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
   #admin
   namespace :admin do
     get "/dashboard", to: "dashboard#show"
+    get '/users', to: 'users#index'
     get "/users/:user_id", to: "users#show"
     get '/users/:user_id/orders', to: 'users_orders#index'
     resources :orders, only: [:update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/dashboard", to: "dashboard#show"
     get "/users/:user_id", to: "users#show"
+    get '/users/:user_id/orders', to: 'users_orders#index'
     resources :orders, only: [:update]
     resources :merchants
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
     get '/users', to: 'users#index'
     get "/users/:user_id", to: "users#show"
     get '/users/:user_id/orders', to: 'users_orders#index'
+    get '/merchants', to: 'merchants#index'
     resources :orders, only: [:update]
     resources :merchants
   end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe "As an admin,", type: :feature do 
-  describe "when I visit the admin's merchant index page ('/admin/merchants')" do 
-    before :each do 
+RSpec.describe "As an admin,", type: :feature do
+  describe "when I visit the admin's merchant index page ('/admin/merchants')" do
+    before :each do
       @admin = User.create!(name: "Jordan Sewell", address:"321 Fake St.", city: "Arvada", state: "CO", zip: "80301", email: "chunky_admin@example.com", password: "123password", role: 2)
       @dog_shop = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210, enabled?: true)
       @bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203, enabled?: true)
@@ -14,44 +14,95 @@ RSpec.describe "As an admin,", type: :feature do
       @dog_bone = @dog_shop.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
       @dog_ball = @dog_shop.items.create(name: "Dog Ball", description: "Awesome dog ball!", price: 5, image: "https://img.chewy.com/is/image/catalog/59155_MAIN._AC_SL1500_V1518033665_.jpg", inventory: 20)
       @dog_bowl = @dog_shop.items.create(name: "Dog Bowl", description: "Great dog bowl!", price: 7, image: "https://www.talltailsdog.com/pub/media/catalog/product/cache/a0f79b354624f8eb0e90cc12a21406d2/u/n/untitled-6.jpg", inventory: 32)
-    end 
-    
-    it "then I see a 'disable' button next to active mechants that, when clicked, returns me to admin merchant index where I see merchant account disabled and flash message." do 
-      visit admin_merchants_path 
+    end
 
-      within "#merchant-#{@bike_shop.id}" do 
+    it "then I see a 'disable' button next to active mechants that, when clicked, returns me to admin merchant index where I see merchant account disabled and flash message." do
+      visit admin_merchants_path
+
+      within "#merchant-#{@bike_shop.id}" do
         expect(page).to have_link("Disable Merchant")
       end
-      
-      within "#merchant-#{@dog_shop.id}" do 
+
+      within "#merchant-#{@dog_shop.id}" do
         expect(page).to have_link("Disable Merchant")
         click_on "Disable Merchant"
       end
 
       expect(current_path).to eq(admin_merchants_path)
-      
-      within "#merchant-#{@dog_shop.id}" do 
+
+      within "#merchant-#{@dog_shop.id}" do
         expect(page).to_not have_link("Disable Merchant")
       end
       expect(page).to have_content("#{@dog_shop.name} is now disabled.")
-      
+
       visit "/merchants/#{@dog_shop.id}/items"
 
-      within "#item-#{@pull_toy.id}" do 
+      within "#item-#{@pull_toy.id}" do
         expect(page).to have_content("Inactive")
       end
 
       within "#item-#{@dog_bone.id}" do
-        expect(page).to have_content("Inactive") 
+        expect(page).to have_content("Inactive")
       end
 
-      within "#item-#{@dog_ball.id}" do 
+      within "#item-#{@dog_ball.id}" do
         expect(page).to have_content("Inactive")
       end
-      
-      within "#item-#{@dog_bowl.id}" do 
+
+      within "#item-#{@dog_bowl.id}" do
         expect(page).to have_content("Inactive")
       end
-    end 
-  end 
-end 
+    end
+
+    context "when a merchant is disabled i see a link to enable that merchant and when i click 'enable'" do
+      it "the merchant is enabled and i get a confirmation flash message and see the 'disable' button again" do
+
+        visit admin_merchants_path
+
+        within "#merchant-#{@bike_shop.id}" do
+          expect(page).to have_link("Disable Merchant")
+        end
+
+        within "#merchant-#{@dog_shop.id}" do
+          expect(page).to have_link("Disable Merchant")
+          click_on "Disable Merchant"
+        end
+
+        expect(current_path).to eq(admin_merchants_path)
+
+        within "#merchant-#{@dog_shop.id}" do
+          expect(page).to_not have_link("Disable Merchant")
+          expect(page).to have_link("Enable Merchant")
+        end
+
+        expect(page).to have_content("#{@dog_shop.name} is now disabled.")
+
+        within "#merchant-#{@dog_shop.id}" do
+          click_on "Enable Merchant"
+        end
+
+        expect(current_path).to eq(admin_merchants_path)
+        expect(page).to have_content("#{@dog_shop.name} is now enabled.")
+
+        visit "/merchants/#{@dog_shop.id}/items"
+
+        within "#item-#{@pull_toy.id}" do
+          expect(page).to have_content("Active")
+        end
+
+        within "#item-#{@dog_bone.id}" do
+          expect(page).to have_content("Active")
+        end
+
+        within "#item-#{@dog_ball.id}" do
+          expect(page).to have_content("Active")
+        end
+
+        within "#item-#{@dog_bowl.id}" do
+          expect(page).to have_content("Active")
+        end
+
+      end
+    end
+  end
+end

--- a/spec/features/admin/users/user_profile_spec.rb
+++ b/spec/features/admin/users/user_profile_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe "as an admin, when i visit a user profile page", type: :feature do
+  it "i see everything the user would see but no link to edit their profile" do
+
+    dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+    dog_bowl = dog_shop.items.create(name: "Dog Bowl", description: "Great dog bowl!", price: 7, image: "https://www.talltailsdog.com/pub/media/catalog/product/cache/a0f79b354624f8eb0e90cc12a21406d2/u/n/untitled-6.jpg", inventory: 32)
+    dog_ball = dog_shop.items.create(name: "Dog Ball", description: "Awesome dog ball!", price: 5, image: "https://img.chewy.com/is/image/catalog/59155_MAIN._AC_SL1500_V1518033665_.jpg", inventory: 20)
+    dog_leash = dog_shop.items.create(name: "Dog Leash", description: "Sturdy dog leash!", price: 10, image: "https://cdn.shopify.com/s/files/1/1728/3089/products/max_and_neo_small_dog_leash_black.jpg?v=1555617800", inventory: 11)
+
+    user1 = User.create(
+      name: 'Steve Meyers',
+      address: '555 Free St.',
+      city: 'Plano',
+      state: 'TX',
+      zip: '88992',
+      email: "user1@example.com",
+      password: "userpassword1")
+    user2 = User.create(
+      name: 'Jordan Sewell',
+      address: '123 Fake St.',
+      city: 'Arvada',
+      state: 'CO',
+      zip: '80301',
+      email: "user2@example.com",
+      password: "userpassword2")
+
+    order1 = user2.orders.create(name: 'Steve Meyers', address: '555 Free St.', city: 'Plano', state: 'TX', zip: '88992', status: 2)
+    order2 = user2.orders.create(name: 'Steve Meyers', address: '555 Free St.', city: 'Plano', state: 'TX', zip: '88992')
+    ItemOrder.create(item: dog_bowl, order: order1, price: dog_bowl.price, quantity: 1)
+    ItemOrder.create(item: dog_leash, order: order1, price: dog_leash.price, quantity: 1)
+    ItemOrder.create(item: dog_ball, order: order2, price: dog_ball.price, quantity: 2)
+
+    admin = User.create(
+      name: "Jordan Admin",
+      address:"321 Fake St.",
+      city: "Arvada",
+      state: "CO",
+      zip: "80301",
+      email: "admin@example.com",
+      password: "password_admin",
+      role: 2)
+
+    visit "/login"
+    fill_in :Email, with: admin.email
+    fill_in :Password, with: admin.password
+    click_button "Login"
+
+    visit "/admin/users/#{user1.id}"
+
+    expect(page).to have_content("Name: #{user1.name}")
+    expect(page).to have_content("Address: #{user1.address}")
+    expect(page).to have_content("City: #{user1.city}")
+    expect(page).to have_content("State: #{user1.state}")
+    expect(page).to have_content("Zip: #{user1.zip}")
+    expect(page).to have_content("Email: #{user1.email}")
+    expect(page).to_not have_content(user1.password)
+    expect(page).to_not have_link("Orders for #{user1.name}")
+    expect(page).to_not have_link("Edit Password")
+    expect(page).to_not have_link("Edit My Profile")
+
+    visit "/admin/users/#{user2.id}"
+
+    expect(page).to have_content("Name: #{user2.name}")
+    expect(page).to have_content("Address: #{user2.address}")
+    expect(page).to have_content("City: #{user2.city}")
+    expect(page).to have_content("State: #{user2.state}")
+    expect(page).to have_content("Zip: #{user2.zip}")
+    expect(page).to have_content("Email: #{user2.email}")
+    expect(page).to_not have_content(user2.password)
+    expect(page).to have_link("Orders for #{user2.name}")
+    expect(page).to_not have_link("Edit Password")
+    expect(page).to_not have_link("Edit My Profile")
+
+    click_link "Orders for #{user2.name}"
+
+    expect(current_path).to eq("/admin/users/#{user2.id}/orders")
+
+    within("#order-#{order1.id}") do
+      expect(page).to have_content("Order - #{order1.id}")
+      expect(page).to have_content("Date Placed: #{order1.created_at}")
+      expect(page).to have_content("Date Last Updated: #{order1.updated_at}")
+      expect(page).to have_content("Status: #{order1.status}")
+      expect(page).to have_content("Item Quantity: #{order1.total_item_quantity}")
+      expect(page).to have_content("Grand Total: #{order1.grandtotal}")
+    end
+    within("#order-#{order2.id}") do
+      expect(page).to have_content("Order - #{order2.id}")
+      expect(page).to have_content("Date Placed: #{order2.created_at}")
+      expect(page).to have_content("Date Last Updated: #{order2.updated_at}")
+      expect(page).to have_content("Status: #{order2.status}")
+      expect(page).to have_content("Item Quantity: #{order2.total_item_quantity}")
+      expect(page).to have_content("Grand Total: #{order2.grandtotal}")
+    end
+  end
+end

--- a/spec/features/admin/users/users_index_spec.rb
+++ b/spec/features/admin/users/users_index_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe "as an admin, when i click 'Users' link in admin nav bar", type: :feature do
+  context "my admin only route is '/admin/users' and i see all system users" do
+    it "each name is a user show page link and i see date registered and user type" do
+
+      dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+      user1 = User.create(name: "Jordan Regular", address:"321 Fake St.", city: "Arvada", state: "CO", zip: "80301", email: "user@example.com", password: "password_regular")
+      user2 = dog_shop.users.create(name: "Jordan Employee", address:"321 Fake St.", city: "Arvada", state: "CO", zip: "80301", email: "merchant@example.com", password: "password_merchant", role: 1)
+      user3 = User.create(name: "Jordan Admin", address:"321 Fake St.", city: "Arvada", state: "CO", zip: "80301", email: "admin@example.com", password: "password_admin", role: 2)
+      customer1 = User.create(name: 'Steve Meyers', address: '555 Free St.', city: 'Plano', state: 'TX', zip: '88992', email: "user1@example.com", password: "user1")
+      customer2 = User.create(name: 'Jordan Sewell', address: '123 Fake St.', city: 'Arvada', state: 'CO', zip: '80301', email: "user2@example.com", password: "user2")
+
+      visit '/'
+
+      within 'nav' do
+        expect(page).to_not have_link('See all Users')
+      end
+
+      visit "/login"
+      fill_in :Email, with: user1.email
+      fill_in :Password, with: user1.password
+      click_button "Login"
+
+      visit '/'
+      within 'nav' do
+        expect(page).to_not have_link('See all Users')
+        click_link "Logout"
+      end
+
+      visit "/login"
+      fill_in :Email, with: user2.email
+      fill_in :Password, with: user2.password
+      click_button "Login"
+
+      within 'nav' do
+        expect(page).to_not have_link('See all Users')
+        click_link "Logout"
+      end
+
+      visit "/login"
+      fill_in :Email, with: user3.email
+      fill_in :Password, with: user3.password
+      click_button "Login"
+
+      within 'nav' do
+        expect(page).to have_link('See all Users')
+        click_link "See all Users"
+      end
+
+      expect(current_path).to eq("/admin/users")
+      expect(page).to have_link("#{user1.name}")
+      expect(page).to have_content(user1.created_at.to_date)
+      expect(page).to have_content(user1.role)
+      expect(page).to have_link("#{user2.name}")
+      expect(page).to have_content(user2.created_at.to_date)
+      expect(page).to have_content(user2.role)
+      expect(page).to have_link("#{user3.name}")
+      expect(page).to have_content(user3.created_at.to_date)
+      expect(page).to have_content(user3.role)
+      expect(page).to have_link("#{customer1.name}")
+      expect(page).to have_content(customer1.created_at.to_date)
+      expect(page).to have_content(customer1.role)
+      expect(page).to have_link("#{customer2.name}")
+      expect(page).to have_content(customer2.created_at.to_date)
+      expect(page).to have_content(customer2.role)
+
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -68,7 +68,7 @@ describe Merchant, type: :model do
       order_2.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       order_3.item_orders.create!(item: pull_toy, price: pull_toy.price, quantity: 2)
       order_4.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
-      
+
       expect(@meg.pending_orders).to eq([order_2])
       expect(dog_shop.pending_orders).to eq([order_1])
     end
@@ -76,10 +76,20 @@ describe Merchant, type: :model do
     it "deactivate_items" do
       dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
       pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", active?: true, inventory: 32)
-      
+
       dog_shop.deactivate_items
-      
+
       expect(pull_toy.active?).to eq(false)
     end
+
+    it "activate_items" do
+      dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+      pull_toy = dog_shop.items.create(name: "Pull Toy", description: "Great pull toy!", price: 10, image: "http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg", active?: false, inventory: 32)
+
+      dog_shop.activate_items
+
+      expect(pull_toy.active?).to eq(true)
+    end
+
   end
 end


### PR DESCRIPTION
US52
  * added test/function for enable/disable button logic for admin/merchants/index
  * added admin/merchants link logic to navbar (it was only going to /merchants/index)

US53
  * added test/function for admin/users/index showing user name, date created, and role
  * user name is a link to the admin/users/show page

US54
  * added test/function for admin/user/show page
  * show page mirrors user profile page except admin do not have access to edit profile or password

all tests passing